### PR TITLE
chore: add cla assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,27 @@
+name: 'CLA Assistant'
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'CLA Assistant'
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/v1/cla.json'
+          path-to-document: 'https://github.com/yasumu-org/yasumu/blob/main/CLA.md'
+          branch: 'main'
+          allowlist: user1,bot*

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,38 @@
+# Contributor License Agreement (CLA)
+
+Thank you for your interest in contributing to the Yasumu project. To safeguard the interests of the Yasumu project, its contributors, and its users, we require all contributors to accept the terms of this Contributor License Agreement (CLA) before any contributions can be merged or incorporated into the project.
+
+The following terms apply to this Agreement:
+
+- **"You"** refers to the individual or legal entity making a Contribution to Yasumu.
+- **"Yasumu"** refers collectively to the Yasumu project, its maintainers, and any associated entities, including any current or future commercial or non-commercial entity managing or deriving from the project.
+- **"Contribution"** refers to any software, code, documentation, design, or other materials submitted by You to Yasumu, whether as an addition, modification, or improvement to the project.
+- **"Work"** refers to the entirety of the Yasumu project, including all past, present, and future contributions from all contributors.
+
+## 1. Grant of Copyright License
+
+By making a Contribution, You hereby grant Yasumu, its maintainers, and recipients of the Work a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license to:
+
+- Reproduce, modify, and prepare derivative works of Your Contribution.
+- Publicly display and publicly perform Your Contribution.
+- Distribute and sublicense Your Contribution and derivative works.
+
+This license applies to both the open-source version of Yasumu and any associated commercial versions. You retain all other rights, title, and interest in Your Contribution unless explicitly stated otherwise in this Agreement.
+
+## 2. Grant of Patent License
+
+By making a Contribution, You hereby grant Yasumu, its maintainers, and recipients of the Work a perpetual, worldwide, non-exclusive, royalty-free, irrevocable (except as stated in this section) license under any patent claims You own or control that are necessarily infringed by:
+
+- Your Contribution alone.
+- The combination of Your Contribution with the Work as it existed at the time of your Contribution.
+
+This license includes the right to make, have made, use, sell, offer to sell, import, and otherwise transfer the Work. If You or any entity acting on Your behalf initiates patent litigation (including cross-claims or counterclaims) against Yasumu or any recipient of the Work alleging that Your Contribution infringes a patent, all patent licenses granted under this Agreement for that Contribution shall terminate immediately.
+
+## 3. Source and Originality of Contributions
+
+By making a Contribution, You represent and warrant that:
+
+1. **Original Work:** Your Contribution is an original work authored solely by You or, if based on prior work, that prior work is appropriately licensed, and You have the right to contribute it under this Agreement.
+2. **Third-Party Content:** If Your Contribution includes materials not authored by You, You have clearly identified those materials and their sources and confirmed their compatibility with the licensing terms of this Agreement.
+3. **No Infringement:** To the best of Your knowledge, Your Contribution does not violate any intellectual property rights, including patents, trademarks, or trade secrets, of any third party.
+4. **Authority:** If You are contributing on behalf of an organization or entity, You have the necessary authority to bind that entity to the terms of this Agreement.

--- a/signatures/v1/cla.json
+++ b/signatures/v1/cla.json
@@ -1,0 +1,3 @@
+{
+  "signedContributors": []
+}


### PR DESCRIPTION
This pull request introduces a Contributor License Agreement (CLA) for the Yasumu project and sets up automation for managing CLA signatures using GitHub Actions. The most important changes include adding a workflow configuration for CLA management and creating the CLA document.

Automation setup for CLA management:

* [`.github/workflows/cla.yml`](diffhunk://#diff-7aa0bb52169dde77e9033b3f574e1c8e686f567ea884691c7aace8f6297d216eR1-R27): Added a new GitHub Actions workflow named 'CLA Assistant' to handle CLA signatures on issue comments and pull request events.

Contributor License Agreement document:

* [`CLA.md`](diffhunk://#diff-4b209274264a92e4c3818b38195f816780b428a7596fb63d2c00cccc137a514fR1-R38): Created a comprehensive Contributor License Agreement document outlining the terms for contributions, including grants of copyright and patent licenses, and representations and warranties by contributors.

> Auto-generated by github copilot